### PR TITLE
Add fleet telematics find sequence service.

### DIFF
--- a/here/fleet_telematics.go
+++ b/here/fleet_telematics.go
@@ -1,0 +1,130 @@
+package here
+
+import (
+	"bytes"
+	"fmt"
+	"net/http"
+	"reflect"
+	"strconv"
+	"time"
+
+	"github.com/dghubble/sling"
+)
+
+// FleetTelematicsService provides for HERE routing api.
+type FleetTelematicsService struct {
+	sling *sling.Sling
+}
+
+// DestinationParams params
+type DestinationParams struct {
+	Coordinates [2]float32
+	StopOver    int
+	Text        string
+}
+
+// FleetTelematicsParams parameters for Fleet Telematics Service.
+type FleetTelematicsParams struct {
+	Start         string `url:"start"`
+	Destination1  string `url:"destination1,omitempty"`
+	Destination2  string `url:"destination2,omitempty"`
+	Destination3  string `url:"destination3,omitempty"`
+	Destination4  string `url:"destination4,omitempty"`
+	Destination5  string `url:"destination5,omitempty"`
+	Destination6  string `url:"destination6,omitempty"`
+	Destination7  string `url:"destination7,omitempty"`
+	Destination8  string `url:"destination8,omitempty"`
+	Destination9  string `url:"destination9,omitempty"`
+	Destination10 string `url:"destination10,omitempty"`
+	End           string `url:"end"`
+	APIKey        string `url:"apikey"`
+	Modes         string `url:"mode"`
+	Departure     string `url:"departure"`
+}
+
+// FleetTelematicsWaypointsSequenceResponse model for fleet telematics service response
+type FleetTelematicsWaypointsSequenceResponse struct {
+	Results []struct {
+		Waypoints []struct {
+			ID                   string    `json:"id"`
+			Lat                  float64   `json:"lat"`
+			Lon                  float64   `json:"lon"`
+			Sequence             uint8     `json:"sequence"`
+			EstimatedArrival     time.Time `json:"estimatedArrival"`
+			EstimatedDeparture   time.Time `json:"estimatedDeparture"`
+			FulFilledConstraints []string  `json:"fulfilledConstraints"`
+		} `json:"waypoints"`
+		Distance         string `json:"distance"`
+		Time             string `json:"time"`
+		InterConnections []struct {
+			FromWaypoint string  `json:"fromWaypoint"`
+			ToWaypoint   string  `json:"toWaypoint"`
+			Distance     float64 `json:"distance"`
+			Time         float64 `json:"time"`
+			Rest         float64 `json:"rest"`
+			Waiting      float64 `json:"waiting"`
+		} `json:"interconnections"`
+		Description   string `json:"description"`
+		TimeBreakdown struct {
+			Driving int `json:"driving"`
+			Service int `json:"service"`
+			Rest    int `json:"rest"`
+			Waiting int `json:"waiting"`
+		}
+	}
+	Errors             []string `json:"errors"`
+	ProcessingTimeDesc string   `json:"processingTimeDesc"`
+	ResponseCode       string   `json:"responseCode"`
+	// TO-DO WARNINGS AND REQUESTID
+}
+
+// newFleetTelematicsService returns a new RoutingService.
+func newFleetTelematicsService(sling *sling.Sling) *FleetTelematicsService {
+	return &FleetTelematicsService{
+		sling: sling,
+	}
+}
+
+// Returns destinations as a formatted string.
+func createDestination(destination DestinationParams) string {
+	if destination.Text != "" {
+		return fmt.Sprintf("%s;%f,%f;", destination.Text, destination.Coordinates[0], destination.Coordinates[1])
+	} else {
+		return fmt.Sprintf("%f,%f;", destination.Coordinates[0], destination.Coordinates[1])
+	}
+}
+
+// CreateFleetTelematicsParams creates fleet telematics parameters struct.
+func (s *FleetTelematicsService) CreateFleetTelematicsParams(start DestinationParams, end DestinationParams, destinations []DestinationParams, apiKey string, modes []Enum) FleetTelematicsParams {
+	var buffer bytes.Buffer
+	for _, routeMode := range modes {
+		mode := Enum.ValueOfRouteMode(routeMode)
+		buffer.WriteString(mode + ";")
+	}
+	routeModes := buffer.String()
+	routeModes = routeModes[:len(routeModes)-1]
+	fleetTelematicsParams := FleetTelematicsParams{
+		Start:     createDestination(start),
+		APIKey:    apiKey,
+		Modes:     routeModes,
+		Departure: "now",
+		End:       createDestination(end),
+	}
+
+	for i, destination := range destinations {
+		stringDestination := createDestination(destination)
+		concatenated := "Destination" + strconv.Itoa(i+1)
+		reflect.ValueOf(&fleetTelematicsParams).Elem().FieldByName(concatenated).SetString(stringDestination)
+	}
+
+	fmt.Printf("%v", fleetTelematicsParams)
+	return fleetTelematicsParams
+}
+
+// FindSequence with given parameters.
+func (s *FleetTelematicsService) FindSequence(params *FleetTelematicsParams) (*FleetTelematicsWaypointsSequenceResponse, *http.Response, error) {
+	routes := new(FleetTelematicsWaypointsSequenceResponse)
+	apiError := new(APIError)
+	resp, err := s.sling.New().Get("findsequence.json").QueryStruct(params).Receive(routes, apiError)
+	return routes, resp, relevantError(err, *apiError)
+}

--- a/here/fleet_telematics_test.go
+++ b/here/fleet_telematics_test.go
@@ -1,0 +1,51 @@
+package here
+
+import (
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestFleetTelematicsService_Route(t *testing.T) {
+	h := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Write(readJSONFile("resources/routing_response.json"))
+	})
+	httpClient, teardown := testingHTTPClient(h)
+	defer teardown()
+
+	client := NewFleetTelematicsClient(httpClient)
+
+	start := DestinationParams{
+		Coordinates: [2]float32{-25.643787, -49.158607},
+		StopOver:    0,
+		Text:        "Start",
+	}
+
+	end := DestinationParams{
+		Coordinates: [2]float32{-20.778591, -51.591198},
+		StopOver:    0,
+		Text:        "Start",
+	}
+
+	destinations := []DestinationParams{
+		{
+			Coordinates: [2]float32{-25.644764, -49.158558},
+			StopOver:    0,
+			Text:        "Destination1"},
+		{
+			Coordinates: [2]float32{-22.98319, -49.903282},
+			StopOver:    0,
+			Text:        "Destination2"},
+		{
+			Coordinates: [2]float32{-20.778555, -51.591164},
+			StopOver:    0,
+			Text:        "Destination2"},
+	}
+
+	params := client.FleetTelematics.CreateFleetTelematicsParams(start, end, destinations, "apiKey", []Enum{RouteMode.Fastest, RouteMode.Truck})
+	routes, _, err := client.FleetTelematics.FindSequence(&params)
+	// TO-DO IMPROVE VALIDATIONS
+	assert.NotNil(t, routes)
+	assert.Nil(t, err)
+}

--- a/here/here.go
+++ b/here/here.go
@@ -11,6 +11,7 @@ type Client struct {
 	sling *sling.Sling
 	// HERE API Services
 	Routing               *RoutingService
+	FleetTelematics       *FleetTelematicsService
 	Geocoding             *GeocodingService
 	ReverseGeocoding      *ReverseGeocodingService
 	AutocompleteGeocoding *AutocompleteGeocodingService
@@ -25,6 +26,15 @@ func NewRoutingClient(httpClient *http.Client) *Client {
 	return &Client{
 		sling:   base,
 		Routing: newRoutingService(base.New()),
+	}
+}
+
+// NewFleetTelematicsClient returns a new NewFleetTelematicsClient.
+func NewFleetTelematicsClient(httpClient *http.Client) *Client {
+	base := sling.New().Client(httpClient).Base("https://wse.ls.hereapi.com/2/")
+	return &Client{
+		sling:           base,
+		FleetTelematics: newFleetTelematicsService(base.New()),
 	}
 }
 

--- a/here/resources/fleet_telematics_find_sequence_response.json
+++ b/here/resources/fleet_telematics_find_sequence_response.json
@@ -1,0 +1,135 @@
+{
+    "results": [
+        {
+            "waypoints": [
+                {
+                    "id": "start",
+                    "lat": -25.643787,
+                    "lng": -49.158607,
+                    "sequence": 0,
+                    "estimatedArrival": null,
+                    "estimatedDeparture": "2020-05-21T19:58:16Z",
+                    "fulfilledConstraints": []
+                },
+                {
+                    "id": "destination5",
+                    "lat": -23.723181,
+                    "lng": -46.605808,
+                    "sequence": 1,
+                    "estimatedArrival": null,
+                    "estimatedDeparture": "2020-05-22T03:43:21Z",
+                    "fulfilledConstraints": []
+                },
+                {
+                    "id": "destination4",
+                    "lat": -23.723181,
+                    "lng": -46.605808,
+                    "sequence": 2,
+                    "estimatedArrival": null,
+                    "estimatedDeparture": "2020-05-22T03:43:21Z",
+                    "fulfilledConstraints": []
+                },
+                {
+                    "id": "destination3",
+                    "lat": -20.778555,
+                    "lng": -51.591164,
+                    "sequence": 3,
+                    "estimatedArrival": null,
+                    "estimatedDeparture": "2020-05-22T14:19:15Z",
+                    "fulfilledConstraints": []
+                },
+                {
+                    "id": "destination2",
+                    "lat": -22.983191,
+                    "lng": -49.903282,
+                    "sequence": 4,
+                    "estimatedArrival": null,
+                    "estimatedDeparture": "2020-05-22T20:41:16Z",
+                    "fulfilledConstraints": []
+                },
+                {
+                    "id": "destination1",
+                    "lat": -25.644764,
+                    "lng": -49.158558,
+                    "sequence": 5,
+                    "estimatedArrival": null,
+                    "estimatedDeparture": "2020-05-23T06:15:58Z",
+                    "fulfilledConstraints": []
+                },
+                {
+                    "id": "end",
+                    "lat": -25.643787,
+                    "lng": -49.158607,
+                    "sequence": 6,
+                    "estimatedArrival": "2020-05-23T06:16:28Z",
+                    "estimatedDeparture": null,
+                    "fulfilledConstraints": []
+                }
+            ],
+            "distance": "1997075",
+            "time": "123492",
+            "interconnections": [
+                {
+                    "fromWaypoint": "start",
+                    "toWaypoint": "destination5",
+                    "distance": 439328.0,
+                    "time": 27905.0,
+                    "rest": 0.0,
+                    "waiting": 0.0
+                },
+                {
+                    "fromWaypoint": "destination5",
+                    "toWaypoint": "destination4",
+                    "distance": 0.0,
+                    "time": 0.0,
+                    "rest": 0.0,
+                    "waiting": 0.0
+                },
+                {
+                    "fromWaypoint": "destination4",
+                    "toWaypoint": "destination3",
+                    "distance": 722082.0,
+                    "time": 38154.0,
+                    "rest": 0.0,
+                    "waiting": 0.0
+                },
+                {
+                    "fromWaypoint": "destination3",
+                    "toWaypoint": "destination2",
+                    "distance": 388025.0,
+                    "time": 22921.0,
+                    "rest": 0.0,
+                    "waiting": 0.0
+                },
+                {
+                    "fromWaypoint": "destination2",
+                    "toWaypoint": "destination1",
+                    "distance": 447533.0,
+                    "time": 34482.0,
+                    "rest": 0.0,
+                    "waiting": 0.0
+                },
+                {
+                    "fromWaypoint": "destination1",
+                    "toWaypoint": "end",
+                    "distance": 107.0,
+                    "time": 30.0,
+                    "rest": 0.0,
+                    "waiting": 0.0
+                }
+            ],
+            "description": "Targeted best time; without traffic",
+            "timeBreakdown": {
+                "driving": 123492,
+                "service": 0,
+                "rest": 0,
+                "waiting": 0
+            }
+        }
+    ],
+    "errors": [],
+    "processingTimeDesc": "921ms",
+    "responseCode": "200",
+    "warnings": null,
+    "requestId": null
+}


### PR DESCRIPTION
- Add new file `fleet_telematics.go` to integrate with the Fleet Telematics Waypoints Sequence Here service (https://developer.here.com/documentation/routing-waypoints/dev_guide/topics/what-is.html).
